### PR TITLE
Fix qmlls path detection

### DIFF
--- a/src/qmljs.rs
+++ b/src/qmljs.rs
@@ -15,15 +15,18 @@ impl QmlJsExtension {
             return Ok(path.clone());
         }
 
-        let binary_name = "qmlls";
+        // Check for qmlls and qmlls6 binary names
+        let binary_names = ["qmlls", "qmlls6"];
 
-        if let Some(path) = worktree.which(&binary_name) {
-            self.cached_binary_path = Some(path.clone());
-            return Ok(path.clone());
+        for binary_name in binary_names.iter() {
+            if let Some(path) = worktree.which(&binary_name) {
+                self.cached_binary_path = Some(path.clone());
+                return Ok(path.clone());
+            }
         }
 
         Err(
-            "qmlls binary not found in $PATH. Make sure you have a working QT installation on your system.\nCheck the install instructions on Github for further information."
+            "qmlls binary not found in $PATH. Make sure you have a working QT installation on your system.\nCheck the install instructions on Github for further information: https://github.com/lkroll/zed-qml?tab=readme-ov-file#qmlls-lsp"
                 .to_owned(),
         )
     }


### PR DESCRIPTION
This fixes #3 by checking for qmlls and qmlls6, using the path as the Ok Result if it can be found.
I also removed the installation status as I think it does not matter in this case, since the installation of the language server is not done by the extension.
So either it can get the full path of qmlls or it will display an error.