### PR TITLE
updated info on arch installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo dnf install qt6-qtdeclarative-devel
 ##### Arch
 
 ```bash
-sudo pacman -S qt6-declarative
+sudo pacman -S qt6-languageserver
 ```
 
 ##### Void Linux


### PR DESCRIPTION
on arch, the package for qmlls6 is `qt6-languageserver`, by default `qt6-declarative` installs `qmlls` to /usr/lib/qt6/bin, qmlls6 is a seperate package so this updates the readme for arch